### PR TITLE
fix precision error

### DIFF
--- a/contracts/LiquidityGauge.vy
+++ b/contracts/LiquidityGauge.vy
@@ -90,7 +90,7 @@ MAX_REWARDS: constant(uint256) = 8
 TOKENLESS_PRODUCTION: constant(uint256) = 40
 WEEK: constant(uint256) = 604800
 
-VERSION: constant(String[8]) = "v6.1.0"  # <- updated from v6.0.0 (makes rewards semi-permissionless)
+VERSION: constant(String[8]) = "v6.1.1"  # <- updated from v6.0.0 (makes rewards semi-permissionless)
 
 EIP712_TYPEHASH: constant(bytes32) = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
 EIP2612_TYPEHASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")

--- a/contracts/LiquidityGauge.vy
+++ b/contracts/LiquidityGauge.vy
@@ -730,8 +730,8 @@ def recover_remaining(_reward_token: address):
     assert period_finish < block.timestamp
     assert self.reward_data[_reward_token].last_update >= period_finish
 
-    self.claim_data[self.reward_data[_reward_token].distributor][_reward_token] +=\
-        self.reward_remaining[_reward_token] << 128
+    assert ERC20(_reward_token).transfer(self.reward_data[_reward_token].distributor,
+        self.reward_remaining[_reward_token], default_return_value=True)
     self.reward_remaining[_reward_token] = 0
 
 

--- a/contracts/LiquidityGauge.vy
+++ b/contracts/LiquidityGauge.vy
@@ -328,7 +328,7 @@ def _checkpoint_rewards(_user: address, _total_supply: uint256, _claim: bool, _r
             self.reward_data[token].last_update = last_update
 
             rate: uint256 = self.reward_data[token].rate
-            excess: uint256 = self.reward_remaining[token] - (period_finish - last_update) * rate
+            excess: uint256 = self.reward_remaining[token] - (period_finish - last_update + duration) * rate
             integral_change: uint256 = (duration * rate + excess) * 10**18 / _total_supply
             integral += integral_change
             self.reward_data[token].integral = integral
@@ -709,7 +709,7 @@ def deposit_reward_token(_reward_token: address, _amount: uint256, _epoch: uint2
     )
     amount_received = ERC20(_reward_token).balanceOf(self) - amount_received
 
-    total_amount: uint256 = amount_received + self.reward_remaining[_reward_token]
+    total_amount: uint256 = self.reward_remaining[_reward_token] + amount_received
     self.reward_data[_reward_token].rate = total_amount / _epoch
     self.reward_remaining[_reward_token] = total_amount
 


### PR DESCRIPTION
### Problem
Small decimal tokens may have precision error.

### Solution
In order to keep current ABI added `reward_remaining` parameter and adjusted formula so it tries to "push" excess tokens for distribution. Some tokens may still remain after distribution, hence added `recover_remaining`.

Though it doesn't add 18-decimal precision calculations, it reduces error a lot. Let `T = .totalSupply // 10 ** 18`, `rewards = .balanceOf()`, then leftover amount would be `rewards % T`. Additionally any remaining tokens can reused in following distribution.